### PR TITLE
Handle missing code blocks

### DIFF
--- a/lib/Perl/Critic/Policy/CognitiveComplexity/ProhibitExcessCognitiveComplexity.pm
+++ b/lib/Perl/Critic/Policy/CognitiveComplexity/ProhibitExcessCognitiveComplexity.pm
@@ -53,9 +53,11 @@ sub violates {
     my $score = 0;
     my $block = $elem->find_first('PPI::Structure::Block');
 
-    $score += $self->_structure_score($block , 0);
-    $score += $self->_operator_score($block);
-    $score += $self->_recursion_score($block, $name);
+    if ($block) {
+        $score += $self->_structure_score($block, 0);
+        $score += $self->_operator_score($block);
+        $score += $self->_recursion_score($block, $name);
+    }
 
     # return no violation
     return if($score < $self->{'_info_level'});

--- a/t/05_empty_block.t
+++ b/t/05_empty_block.t
@@ -12,7 +12,7 @@ ok( _ensure_no_error($code_sub_declaration_without_body), "Should not fail on su
 my $code_signature_sub_call = <<'END_CODE';
 use feature qw(signatures);
 sub my_sub () {}
-my sub ($arg = my_sub()) {}
+sub call_in_default_arg ($arg = my_sub()) {}
 END_CODE
 ok( _ensure_no_error($code_signature_sub_call), "Should not fail on function call in sub signatures" );
 

--- a/t/05_empty_block.t
+++ b/t/05_empty_block.t
@@ -1,0 +1,27 @@
+use strict;
+use Test::More;
+use Perl::Critic::TestUtils qw( pcritique );
+
+my $policy = 'Perl::Critic::Policy::CognitiveComplexity::ProhibitExcessCognitiveComplexity';
+
+my $code_sub_declaration_without_body = <<'END_CODE';
+sub some_sub ($);
+END_CODE
+ok( _ensure_no_error($code_sub_declaration_without_body), "Should not fail on sub declaration without body" );
+
+my $code_signature_sub_call = <<'END_CODE';
+use feature qw(signatures);
+sub my_sub () {}
+my sub ($arg = my_sub()) {}
+END_CODE
+ok( _ensure_no_error($code_signature_sub_call), "Should not fail on function call in sub signatures" );
+
+sub _ensure_no_error {
+    my $code = shift;
+    return eval {
+        pcritique( $policy, \$code );
+        1;
+    };
+}
+
+done_testing();


### PR DESCRIPTION
Found two cases where the rule would crash related to missing code blocks in the code being criticised.

```perl
sub without_code ($);
```
```perl
use feature qw(signatures);
sub my_sub () {}
sub call_in_default_arg ($arg = my_sub()) {}
```

The fix is just ignore these blocks.